### PR TITLE
ActiveSupport Versionup patch

### DIFF
--- a/activesupport-json_encoder.gemspec
+++ b/activesupport-json_encoder.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = Dir['test/**/*.rb']
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'activesupport', '>= 4.1.0', '< 5.0'
+  gem.add_dependency 'activesupport', '>= 4.1.0', '< 6.0'
 
   gem.add_development_dependency 'rake'
 end

--- a/lib/active_support/json/encoding/active_support_encoder.rb
+++ b/lib/active_support/json/encoding/active_support_encoder.rb
@@ -92,7 +92,7 @@ module ActiveSupport
       end
 
       class << self
-        remove_method :encode_big_decimal_as_string, :encode_big_decimal_as_string=
+        remove_method :encode_big_decimal_as_string, :encode_big_decimal_as_string= rescue NameError
 
         # If false, serializes BigDecimal objects as numeric instead of wrapping
         # them in a string.
@@ -152,7 +152,7 @@ class BigDecimal
 
   def as_json(options = nil) #:nodoc:
     if finite?
-      ActiveSupport.encode_big_decimal_as_string ? to_s : self
+      ActiveSupport::JSON::Encoding.encode_big_decimal_as_string ? to_s : self
     else
       nil
     end

--- a/test/active_support_encoder_test.rb
+++ b/test/active_support_encoder_test.rb
@@ -412,15 +412,15 @@ class TestJSONEncoding < ActiveSupport::TestCase
     big_decimal = BigDecimal('2.5')
 
     begin
-      ActiveSupport.encode_big_decimal_as_string = false
+      ActiveSupport::JSON::Encoding.encode_big_decimal_as_string = false
       assert_equal big_decimal.to_s, big_decimal.to_json
     ensure
-      ActiveSupport.encode_big_decimal_as_string = true
+      ActiveSupport::JSON::Encoding.encode_big_decimal_as_string = true
     end
   end
 
   def test_reading_encode_big_decimal_as_string_option
-    assert_not_deprecated { assert ActiveSupport.encode_big_decimal_as_string }
+    assert_not_deprecated { assert ActiveSupport::JSON::Encoding.encode_big_decimal_as_string }
   end
 
   def test_nil_true_and_false_represented_as_themselves


### PR DESCRIPTION
- change to add_dependency
- change to namespace `ActiveSupport -> ActiveSupport::JSON::Encoding`,  because it's deleted by this commit  https://github.com/rails/rails/commit/c8019c0611791b2716c6bed48ef8dcb177b7869c
